### PR TITLE
Add node-redis and redis-py connection pool documentation

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -5,7 +5,9 @@ An example app connecting to Redis using [ioredis](https://github.com/luin/iored
 
 ## Migrating from your Redis service
 
-The follow code snippet shows the differences between connecting to the old Redis service
+### Using `ioredis`
+
+The following code snippet shows the differences between connecting to the old Redis service
 to the new AWS ElastiCache Redis service. The following app code shows how to configure
 the Redis client with the Redis service bound to the app. See this [ioredis issue](https://github.com/luin/ioredis/issues/1042#issuecomment-575642093) for more information.
 
@@ -41,7 +43,42 @@ const client = new Redis({
 // The Redis `client` is ready to be used
 ```
 
+### Using `node-redis`
+
+The following code snippet shows the differences between connecting to the old Redis service
+to the new AWS ElastiCache Redis service. The following app code shows how to configure
+the Redis client with the Redis service bound to the app. See the source code [node-redis](https://github.com/NodeRedis/node-redis)
+
+```js
+const Redis = require('redis');
+const cfenv = require('cfenv');
+
+
+//
+// The new AWS ElastiCache Redis service named `old-redis-service`
+//
+const redisConfig = appEnv.getService('old-redis-service');
+
+const creds = {
+    url: redisConfig.credentials.uri,
+    tls: null,
+  };
+
+redis.createClient(redisConfig);
+
+//
+// The new AWS ElastiCache Redis service named `new-redis-service`
+//
+const redisConfig = appEnv.getService('new-redis-service');
+
+const creds = {
+    url: redisConfig.credentials.uri,
+    tls: {},
+  };
+
+redis.createClient(redisConfig);
+```
+
 ## Differences in configuration
 
-- The new AWS ElastiCache Redis service credentials has renamed the host name to `host` from `hostname`
 - The `tls` configuration key must be set to an empty object `{}`

--- a/python/README.md
+++ b/python/README.md
@@ -54,3 +54,31 @@ client = redis.Redis(**redis_config)
 - The new AWS ElastiCache Redis service credentials has renamed the host name to `host` from `hostname`
 - The `ssl` configuration key must be set to `True`
 - The `ssl_cert_reqs` configuration key must be set to `None`
+
+
+## Creating a Redis connection pool
+
+This following example shows how you can use `redis-py` to connect via to the new Redis service through [connection pools](https://github.com/andymccurdy/redis-py#connection-pools). You may choose to do this in order to have precise control of how connections are managed.
+
+```python
+from redis import ConnectionPool, SSLConnection
+from cfenv import AppEnv
+
+##
+## The new Redis service `redis`
+## Using `cfenv` module to grab the Redis service from VCAP_SERVICES
+##
+redis_service = cfenv.get_service(label=re.compile("redis.*"))
+
+## Instantiate the Redis connection pool
+connection_pool = ConnectionPool(
+    host=redis_service.credentials["host"],
+    port=redis_service.credentials["port"],
+    password=redis_service.credentials["password"],
+    ssl=True,
+    ssl_cert_reqs=None,
+    connection_class=SSLConnection
+)
+
+## The Redis `connection_pool` is ready to be used
+```


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add docs for setting up a node-redis connection
- Add redis-py connection pool docs based on https://github.com/cloud-gov/external-domain-broker work
- Closes #6 

## Security considerations

None
